### PR TITLE
WIP: Extraction Tracing API

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -1,8 +1,6 @@
-use std;
-
 pub const MAC_LENGTH: usize = 6;
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub struct MacAddress(pub [u8; MAC_LENGTH]);
 
 pub type Vlan = u16;
@@ -21,6 +19,7 @@ impl std::fmt::Display for MacAddress {
         )
     }
 }
+
 
 #[cfg(test)]
 mod tests {

--- a/src/layer2/mod.rs
+++ b/src/layer2/mod.rs
@@ -1,6 +1,17 @@
 use crate::{
     common::*,
-    layer3::Layer3FlowInfo
+    errors::{
+        self,
+        Error,
+        ErrorKind
+    },
+    flow::FlowInfo,
+    layer3::{
+        Layer3FlowInfo,
+        Layer3Protocol,
+    },
+    LayerExtraction,
+    Protocol,
 };
 
 pub mod ethernet;
@@ -13,11 +24,130 @@ pub enum Layer2<'a> {
 }
 
 ///
+/// Layer 2 Protocols.
+///
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum Layer2Protocol {
+    Ethernet
+}
+
+impl std::fmt::Display for Layer2Protocol {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match &self {
+            Layer2Protocol::Ethernet => write!(f, "ethernet"),
+        }
+    }
+}
+
+impl Protocol for Layer2Protocol {}
+
+
+///
 /// Information from Layer 2 protocols used in stream determination
 ///
+#[derive(Debug)]
 pub struct Layer2FlowInfo {
     pub src_mac: MacAddress,
     pub dst_mac: MacAddress,
     pub vlan: Vlan,
-    pub layer3: Layer3FlowInfo
+    pub layer3: LayerExtraction<Layer3Protocol, Layer3FlowInfo>,
+}
+
+impl FlowInfo for Layer2FlowInfo {
+    type P = Layer3Protocol;
+    type F = Layer3FlowInfo;
+
+    fn next_layer(&self) -> &LayerExtraction<Self::P, Self::F> {
+        &self.layer3
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate env_logger;
+
+    use crate::layer2::ethernet::Ethernet;
+    use super::*;
+
+    pub const TCP_RAW_DATA: &'static [u8] = &[
+        0x01u8, 0x02u8, 0x03u8, 0x04u8, 0x05u8, 0x06u8, //dst mac 01:02:03:04:05:06
+        0xFFu8, 0xFEu8, 0xFDu8, 0xFCu8, 0xFBu8, 0xFAu8, //src mac FF:FE:FD:FC:FB:FA
+        0x08u8, 0x00u8, //ipv4
+        //ipv4
+        0x45u8, //version and header length
+        0x00u8, //tos
+        0x00u8, 0x48u8, //length, 20 bytes for header, 52 bytes for ethernet
+        0x00u8, 0x00u8, //id
+        0x00u8, 0x00u8, //flags
+        0x64u8, //ttl
+        0x06u8, //protocol, tcp
+        0x00u8, 0x00u8, //checksum
+        0x01u8, 0x02u8, 0x03u8, 0x04u8, //src ip 1.2.3.4
+        0x0Au8, 0x0Bu8, 0x0Cu8, 0x0Du8, //dst ip 10.11.12.13
+        //tcp
+        0xC6u8, 0xB7u8, //src port, 50871
+        0x00u8, 0x50u8, //dst port, 80
+        0x00u8, 0x00u8, 0x00u8, 0x01u8, //sequence number, 1
+        0x00u8, 0x00u8, 0x00u8, 0x02u8, //acknowledgement number, 2
+        0x50u8, 0x00u8, //header and flags, 0
+        0x00u8, 0x00u8, //window
+        0x00u8, 0x00u8, //check
+        0x00u8, 0x00u8, //urgent
+        //no options
+        //payload
+        0x01u8, 0x02u8, 0x03u8, 0x04u8,
+        0x00u8, 0x00u8, 0x00u8, 0x00u8,
+        0x00u8, 0x00u8, 0x00u8, 0x00u8,
+        0x00u8, 0x00u8, 0x00u8, 0x00u8,
+        0x00u8, 0x00u8, 0x00u8, 0x00u8,
+        0x00u8, 0x00u8, 0x00u8, 0x00u8,
+        0x00u8, 0x00u8, 0x00u8, 0x00u8,
+        0xfcu8, 0xfdu8, 0xfeu8, 0xffu8 //payload, 8 words
+    ];
+
+    const BAD_IPV4_DATA: &'static [u8] = &[
+        0x01u8, 0x02u8, 0x03u8, 0x04u8, 0x05u8, 0x06u8, //dst mac 01:02:03:04:05:06
+        0xFFu8, 0xFEu8, 0xFDu8, 0xFCu8, 0xFBu8, 0xFAu8, //src mac FF:FE:FD:FC:FB:FA
+        0x08u8, 0x00u8, //ipv4
+        //ipv4
+        0x45u8, //version and header length
+        0x00u8, //tos
+        0xFFu8, 0x48u8, //length, 20 bytes for header, 52 bytes for ethernet **header length too large**
+        0x00u8, 0x00u8, //id
+        0x00u8, 0x00u8, //flags
+        0x64u8, //ttl
+        0x06u8, //protocol, tcp
+        0x00u8, 0x00u8, //checksum
+        0x01u8, 0x02u8, 0x03u8, 0x04u8, //src ip 1.2.3.4
+        0x0Au8, 0x0Bu8, 0x0Cu8, 0x0Du8, //dst ip 10.11.12.13
+    ];
+
+    #[test]
+    fn layer3_trace() {
+        let _ = env_logger::try_init();
+
+        let (rem, l2) = Ethernet::parse(TCP_RAW_DATA).expect("Could not parse");
+
+        assert!(rem.is_empty());
+
+        let layer2 = Layer2FlowInfo::from(l2);
+
+        assert!(layer2.layer3.is_success());
+        assert_eq!(*layer2.layer3.protocol(), Layer3Protocol::IPv4);
+    }
+
+    #[test]
+    fn failing_layer3_trace() {
+        let _ = env_logger::try_init();
+
+        let (rem, l2) = Ethernet::parse(BAD_IPV4_DATA).expect("Could not parse");
+
+        assert!(rem.is_empty());
+
+        let layer2 = Layer2FlowInfo::from(l2);
+
+        // Must fail because the header length is too large (0xFF).
+        assert!(layer2.layer3.is_failure());
+        assert_eq!(*layer2.layer3.protocol(), Layer3Protocol::IPv4);
+    }
 }

--- a/src/layer3/ipv6.rs
+++ b/src/layer3/ipv6.rs
@@ -1,3 +1,4 @@
+use arrayref::array_ref;
 use crate::{
     errors::{
         self,
@@ -6,23 +7,24 @@ use crate::{
     },
     layer3::{
         InternetProtocolId,
-        Layer3FlowInfo
+        Layer3FlowInfo,
+        Layer3Protocol,
     },
     layer4::{
         Layer4,
         Layer4FlowInfo,
+        Layer4Protocol,
         tcp::*,
         udp::*
-    }
+    },
+    LayerExtraction
 };
-use arrayref::array_ref;
 use log::*;
 use nom::{
     *,
     Err as NomError,
     ErrorKind as NomErrorKind
 };
-use std;
 use std::convert::TryFrom;
 
 const ADDRESS_LENGTH: usize = 16;
@@ -135,35 +137,43 @@ impl<'a> IPv6<'a> {
     }
 }
 
-impl<'a> TryFrom<IPv6<'a>> for Layer3FlowInfo {
-    type Error = errors::Error;
+impl<'a> From<IPv6<'a>> for Layer3FlowInfo {
+//    type Error = errors::Error;
 
-    fn try_from(value: IPv6<'a>) -> Result<Self, Self::Error> {
+    fn from(value: IPv6<'a>) -> Self {
         debug!("Creating stream info from {:?}", value.protocol);
+
+        let mut protocol = Layer4Protocol::Unknown;
+
         let l4 = match value.protocol.clone() {
             InternetProtocolId::Tcp => {
+                protocol = Layer4Protocol::Tcp;
+
                 Tcp::parse(value.payload())
                     .map_err(|e| {
-                        let err: Self::Error = e.into();
+                        let err: errors::Error = e.into();
                         err.chain_err(|| errors::Error::from_kind(errors::ErrorKind::FlowParse))
                     }).and_then(|r| {
                     let (rem, l4) = r;
                     if rem.is_empty() {
-                        Layer4FlowInfo::try_from(l4)
+                        Ok(Layer4FlowInfo::from(l4))
                     } else {
                         Err(errors::Error::from_kind(errors::ErrorKind::L3IncompleteParse(rem.len())))
                     }
                 })
             }
             InternetProtocolId::Udp => {
+                protocol = Layer4Protocol::Udp;
+
                 Udp::parse(value.payload())
                     .map_err(|e| {
-                        let err: Self::Error = e.into();
+                        let err: errors::Error = e.into();
                         err.chain_err(|| errors::Error::from_kind(errors::ErrorKind::FlowParse))
+
                     }).and_then(|r| {
                     let (rem, l4) = r;
                     if rem.is_empty() {
-                        Layer4FlowInfo::try_from(l4)
+                        Ok(Layer4FlowInfo::from(l4))
                     } else {
                         Err(errors::Error::from_kind(errors::ErrorKind::L3IncompleteParse(rem.len())))
                     }
@@ -172,13 +182,15 @@ impl<'a> TryFrom<IPv6<'a>> for Layer3FlowInfo {
             _ => {
                 Err(errors::Error::from_kind(errors::ErrorKind::IPv4Type(value.protocol)))
             }
-        }?;
+        };
 
-        Ok(Layer3FlowInfo {
+        let l4_extraction = LayerExtraction::map_extraction(protocol, l4);
+
+        Layer3FlowInfo {
             src_ip: value.src_ip,
             dst_ip: value.dst_ip,
-            layer4: l4
-        })
+            layer4: l4_extraction,
+        }
     }
 }
 
@@ -186,8 +198,8 @@ impl<'a> TryFrom<IPv6<'a>> for Layer3FlowInfo {
 mod tests {
     extern crate env_logger;
     extern crate hex_slice;
-    use self::hex_slice::AsHex;
 
+    use self::hex_slice::AsHex;
     use super::*;
 
     const RAW_DATA: &'static [u8] = &[
@@ -225,18 +237,10 @@ mod tests {
 
         let (rem, l3) = IPv6::parse(RAW_DATA).expect("Unable to parse");
 
+        assert!(rem.is_empty());
         assert_eq!(*l3.src_ip(), "102:304:506:708:90A:B0C:D0E:F0F".parse::<std::net::IpAddr>().expect("Could not parse ip address"));
         assert_eq!(*l3.dst_ip(), "F00:102:304:506:708:90A:B0C:D0E".parse::<std::net::IpAddr>().expect("Could not parse ip address"));
-
-        let is_tcp = if let InternetProtocolId::Tcp = l3.protocol() {
-            true
-        } else {
-            false
-        };
-
-        assert!(is_tcp);
-
-        assert!(rem.is_empty());
+        assert_eq!(*l3.protocol(), InternetProtocolId::Tcp);
     }
     #[test]
     fn convert_ipv6() {
@@ -244,11 +248,14 @@ mod tests {
 
         let (rem, l3) = IPv6::parse(RAW_DATA).expect("Unable to parse");
 
-        let info = Layer3FlowInfo::try_from(l3).expect("Could not convert to layer 3 info");
+        let info = Layer3FlowInfo::from(l3);
 
         assert_eq!(info.src_ip, "102:304:506:708:90A:B0C:D0E:F0F".parse::<std::net::IpAddr>().expect("Could not parse ip address"));
         assert_eq!(info.dst_ip, "F00:102:304:506:708:90A:B0C:D0E".parse::<std::net::IpAddr>().expect("Could not parse ip address"));
-        assert_eq!(info.layer4.src_port, 50871);
-        assert_eq!(info.layer4.dst_port, 80);
+
+        let layer4 = info.layer4.unwrap_flow();
+
+        assert_eq!(layer4.src_port, 50871);
+        assert_eq!(layer4.dst_port, 80);
     }
 }

--- a/src/layer3/mod.rs
+++ b/src/layer3/mod.rs
@@ -1,10 +1,24 @@
+use crate::{
+    errors::{
+        self,
+        Error,
+        ErrorKind
+    },
+    flow::FlowInfo,
+    layer4::{
+        Layer4FlowInfo,
+        Layer4Protocol
+    },
+    LayerExtraction,
+    Protocol
+};
+use log::*;
+
 pub mod arp;
 pub mod ipv4;
 pub mod ipv6;
 pub mod lldp;
 
-use log::*;
-use std;
 
 ///
 /// Available layer 3 representations
@@ -17,12 +31,48 @@ pub enum Layer3<'a> {
 }
 
 ///
+/// Layer 2 Protocols
+///
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum Layer3Protocol {
+    IPv4,
+    IPv6,
+    Arp,
+    Lldp,
+    Unknown,
+}
+
+impl std::fmt::Display for Layer3Protocol {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match &self {
+            Layer3Protocol::IPv4 => write!(f, "{}", "ipv4"),
+            Layer3Protocol::IPv6 => write!(f, "{}", "ipv6"),
+            Layer3Protocol::Arp => write!(f, "{}", "arp"),
+            Layer3Protocol::Lldp => write!(f, "{}", "lldp"),
+            Layer3Protocol::Unknown => write!(f, "{}", "unknown"),
+        }
+    }
+}
+
+impl Protocol for Layer3Protocol {}
+
+///
 /// Information from Layer 3 protocols used in stream determination
 ///
+#[derive(Debug)]
 pub struct Layer3FlowInfo {
     pub dst_ip: std::net::IpAddr,
     pub src_ip: std::net::IpAddr,
-    pub layer4: crate::layer4::Layer4FlowInfo
+    pub layer4: LayerExtraction<Layer4Protocol, Layer4FlowInfo>,
+}
+
+impl FlowInfo for Layer3FlowInfo {
+    type P = Layer4Protocol;
+    type F = Layer4FlowInfo;
+
+    fn next_layer(&self) -> &LayerExtraction<Self::P, Self::F> {
+        &self.layer4
+    }
 }
 
 ///
@@ -74,4 +124,105 @@ impl InternetProtocolId {
             _ => false
         }
     }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate env_logger;
+    extern crate hex_slice;
+
+    use crate::layer3::{ipv4::IPv4, Layer3, Layer3FlowInfo};
+    use crate::layer4::Layer4Protocol;
+    use crate::LayerExtraction;
+
+    const TCP_RAW_DATA: &'static [u8] = &[
+        0x45u8, //version and header length
+        0x00u8, //tos
+        0x00u8, 0x48u8, //length, 20 bytes for header, 52 bytes for ethernet
+        0x00u8, 0x00u8, //id
+        0x00u8, 0x00u8, //flags
+        0x64u8, //ttl
+        0x06u8, //protocol, tcp
+        0x00u8, 0x00u8, //checksum
+        0x01u8, 0x02u8, 0x03u8, 0x04u8, //src ip 1.2.3.4
+        0x0Au8, 0x0Bu8, 0x0Cu8, 0x0Du8, //dst ip 10.11.12.13
+        //tcp
+        0xC6u8, 0xB7u8, //src port, 50871
+        0x00u8, 0x50u8, //dst port, 80
+        0x00u8, 0x00u8, 0x00u8, 0x01u8, //sequence number, 1
+        0x00u8, 0x00u8, 0x00u8, 0x02u8, //acknowledgement number, 2
+        0x50u8, 0x00u8, //header and flags, 0
+        0x00u8, 0x00u8, //window
+        0x00u8, 0x00u8, //check
+        0x00u8, 0x00u8, //urgent
+        //no options
+        //payload
+        0x01u8, 0x02u8, 0x03u8, 0x04u8,
+        0x00u8, 0x00u8, 0x00u8, 0x00u8,
+        0x00u8, 0x00u8, 0x00u8, 0x00u8,
+        0x00u8, 0x00u8, 0x00u8, 0x00u8,
+        0x00u8, 0x00u8, 0x00u8, 0x00u8,
+        0x00u8, 0x00u8, 0x00u8, 0x00u8,
+        0x00u8, 0x00u8, 0x00u8, 0x00u8,
+        0xfcu8, 0xfdu8, 0xfeu8, 0xffu8 //payload, 8 words
+    ];
+
+    const BAD_TCP_DATA: &'static [u8] = &[
+        // ipv4
+        0x45u8, //version and header length
+        0x00u8, //tos
+        0x00u8, 0x48u8, //length, 20 bytes for header, 52 bytes for ethernet
+        0x00u8, 0x00u8, //id
+        0x00u8, 0x00u8, //flags
+        0x64u8, //ttl
+        0x06u8, //protocol, tcp
+        0x00u8, 0x00u8, //checksum
+        0x01u8, 0x02u8, 0x03u8, 0x04u8, //src ip 1.2.3.4
+        0x0Au8, 0x0Bu8, 0x0Cu8, 0x0Du8, //dst ip 10.11.12.13
+        //tcp
+        0xC6u8, 0xB7u8, //src port, 50871
+        0x00u8, 0x50u8, //dst port, 80
+        0x00u8, 0x00u8, 0x00u8, 0x01u8, //sequence number, 1
+        0x00u8, 0x00u8, 0x00u8, 0x02u8, //acknowledgement number, 2
+        0xFFu8, 0x00u8, //header and flags, 0 **length is too large**
+        0x00u8, 0x00u8, //window
+        0x00u8, 0x00u8, //check
+        0x00u8, 0x00u8, //urgent
+        //no options
+        //payload
+        0x01u8, 0x02u8, 0x03u8, 0x04u8,
+        0x00u8, 0x00u8, 0x00u8, 0x00u8,
+        0x00u8, 0x00u8, 0x00u8, 0x00u8,
+        0x00u8, 0x00u8, 0x00u8, 0x00u8,
+        0x00u8, 0x00u8, 0x00u8, 0x00u8,
+        0x00u8, 0x00u8, 0x00u8, 0x00u8,
+        0x00u8, 0x00u8, 0x00u8, 0x00u8,
+        0xfcu8, 0xfdu8, 0xfeu8, 0xffu8 //payload, 8 words
+    ];
+
+    #[test]
+    fn layer4_trace() {
+        let _ = env_logger::try_init();
+
+        let (rem, l3) = IPv4::parse(TCP_RAW_DATA).expect("Unable to parse");
+
+        let layer3 = Layer3FlowInfo::from(l3);
+
+        assert!(layer3.layer4.is_success());
+        assert_eq!(*layer3.layer4.protocol(), Layer4Protocol::Tcp);
+    }
+
+    #[test]
+    fn failing_layer4_trace() {
+        let _ = env_logger::try_init();
+
+        let (rem, l3) = IPv4::parse(BAD_TCP_DATA).expect("Unable to parse");
+
+        let layer3= Layer3FlowInfo::from(l3);
+
+        // Layer 4 must fail; the TCP length is too large.
+        assert!(layer3.layer4.is_failure());
+        assert_eq!(*layer3.layer4.protocol(), Layer4Protocol::Tcp);
+    }
+
 }

--- a/src/layer4/mod.rs
+++ b/src/layer4/mod.rs
@@ -1,3 +1,14 @@
+use crate::{
+    errors::{
+        self,
+        Error,
+        ErrorKind
+    },
+    flow::FlowInfo,
+    LayerExtraction,
+    Protocol
+};
+
 pub mod tcp;
 pub mod udp;
 
@@ -12,7 +23,44 @@ pub enum Layer4<'a> {
 ///
 /// Information from Layer 4 protocols used in stream determination
 ///
+#[derive(Debug)]
 pub struct Layer4FlowInfo {
     pub dst_port: u16,
-    pub src_port: u16
+    pub src_port: u16,
+    protocol: Layer4Protocol,
 }
+
+impl Layer4FlowInfo {
+    pub fn protocol(&self) -> &Layer4Protocol {
+        &self.protocol
+    }
+}
+
+
+impl FlowInfo for Layer4FlowInfo {
+    type P = Layer4Protocol;
+    type F = Layer4FlowInfo;
+
+    fn next_layer(&self) -> &LayerExtraction<Self::P, Self::F> {
+        &LayerExtraction::None
+    }
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum Layer4Protocol {
+    Tcp,
+    Udp,
+    Unknown,
+}
+
+impl std::fmt::Display for Layer4Protocol {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match &self {
+            Layer4Protocol::Tcp => write!(f, "{}", "tcp"),
+            Layer4Protocol::Udp => write!(f, "{}", "udp"),
+            Layer4Protocol::Unknown => write!(f, "{}", "unknown"),
+        }
+    }
+}
+
+impl Protocol for Layer4Protocol {}

--- a/src/layer4/udp.rs
+++ b/src/layer4/udp.rs
@@ -4,12 +4,13 @@ use crate::{
         Error,
         ErrorKind
     },
-    layer4::Layer4FlowInfo
+    layer4::{
+        Layer4FlowInfo,
+        Layer4Protocol,
+    }
 };
-
 use log::*;
 use nom::*;
-use std;
 use std::convert::TryFrom;
 
 const HEADER_LENGTH: usize = 4 * std::mem::size_of::<u16>();
@@ -67,14 +68,16 @@ impl<'a> Udp<'a> {
     }
 }
 
-impl<'a> TryFrom<Udp<'a>> for Layer4FlowInfo {
-    type Error = errors::Error;
+impl<'a> From<Udp<'a>> for Layer4FlowInfo {
+//    type Error = errors::Error;
 
-    fn try_from(value: Udp<'a>) -> Result<Self, Self::Error> {
-        Ok(Layer4FlowInfo {
+    fn from(value: Udp<'a>) -> Self {
+
+        Layer4FlowInfo {
             dst_port: value.dst_port,
-            src_port: value.src_port
-        })
+            src_port: value.src_port,
+            protocol: Layer4Protocol::Udp,
+        }
     }
 }
 
@@ -82,8 +85,8 @@ impl<'a> TryFrom<Udp<'a>> for Layer4FlowInfo {
 mod tests {
     extern crate env_logger;
     extern crate hex_slice;
-    use self::hex_slice::AsHex;
 
+    use self::hex_slice::AsHex;
     use super::*;
 
     const RAW_DATA: &'static [u8] = &[

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,0 +1,42 @@
+use crate::Outcome;
+
+/*
+pub struct LayerNFlowInfo {
+//    ...
+//    next_layer: Option<LayerMFlowInfo>
+    pub info: Info<L3Trace>,
+}
+
+// The idea I am thinking of switching to. This way
+// All manner of traces can easily be created.
+pub struct Info<I> {
+    pub outcome: Outcome,
+    pub trace: I,
+}
+
+// The type that would hold the information that
+// should be traced. Can be an enum or a struct
+// If the information is complex.
+pub enum L3Trace {
+    Try(usize), // Could be anything
+    None,
+}
+
+
+// Simple PoC
+fn some_function() {
+    let info: Info<L3Trace> = Info {
+        outcome: Outcome::Success,
+        trace: L3Trace::Try(1337),
+    };
+
+    let flow_info = LayerNFlowInfo {
+        info
+    };
+
+    match flow_info.info.trace {
+        L3Trace::Try(n) => println!(n),
+        _ => panic!(),
+    };
+}
+*/


### PR DESCRIPTION
This pull request implements an API that traces the extraction of the LayerNFlowInfo structs from packet data. The main change to each of the `LayerNFlowInfo` structs is the addition of a new member, the `extraction_info`. The `extraction_info` is a simple struct the holds the protocol of the current Layer and the attempted action for the next layer, the trace.

For example:
A parsed packet is `ethernet -> IPv4 -> TCP`. The layer 3 `extraction_info` will report that the current layer's `protocol()` is `Layer3Protocol::IPv4`, and its `trace()` is `Layer3Trace::Try(Layer4Protocol::Tcp)`.