### PR TITLE
Source port comes before Dest port in UDP (not the other way around).

### DIFF
--- a/src/layer4/udp.rs
+++ b/src/layer4/udp.rs
@@ -48,8 +48,8 @@ impl<'a> Udp<'a> {
 
         do_parse!(input,
 
-            dst_port: be_u16 >>
             src_port: be_u16 >>
+            dst_port: be_u16 >>
             length: map!(be_u16, |s| {
                 (s as usize) - HEADER_LENGTH
             }) >>
@@ -87,8 +87,8 @@ mod tests {
     use super::*;
 
     const RAW_DATA: &'static [u8] = &[
-        0xC6u8, 0xB7u8, //dst port, 50871
-        0x00u8, 0x50u8, //src port, 80
+        0xC6u8, 0xB7u8, //src port, 50871
+        0x00u8, 0x50u8, //dst port, 80
         0x00u8, 0x28u8, //length 40, less header length is payload of 32
         0x00u8, 0x00u8, //checksum
         0x01u8, 0x02u8, 0x03u8, 0x04u8,
@@ -109,8 +109,8 @@ mod tests {
 
         assert!(rem.is_empty());
 
-        assert_eq!(l4.dst_port(), 50871);
-        assert_eq!(l4.src_port(), 80);
+        assert_eq!(l4.src_port(), 50871);
+        assert_eq!(l4.dst_port(), 80);
         assert_eq!(l4.payload(), [0x01u8, 0x02u8, 0x03u8, 0x04u8,
             0x00u8, 0x00u8, 0x00u8, 0x00u8,
             0x00u8, 0x00u8, 0x00u8, 0x00u8,
@@ -131,7 +131,7 @@ mod tests {
 
         let info = Layer4FlowInfo::try_from(l4).expect("Could not convert to layer 4 info");
 
-        assert_eq!(info.src_port, 80);
-        assert_eq!(info.dst_port, 50871);
+        assert_eq!(info.dst_port, 80);
+        assert_eq!(info.src_port, 50871);
     }
 }


### PR DESCRIPTION
We had the SRC/DST ports backwards for UDP.  TCP was correct.